### PR TITLE
Add option to use textfield instead of textarea

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,24 +20,30 @@ Props
 ## Content
 Takes your content to render inside the element
 ```html
-<SimpleReactComponent content="hello this thing is editable" />
+<SimpleReactEditable content="hello this thing is editable" />
 ```
 
 ## onEditingOpen
 Fires on when user open textarea to edit text wth textarea value
 ```html
-<SimpleReactComponent onEditingOpen={ (e, value) => { console.log('editing started', value) }} content="hello this thing is editable" />
+<SimpleReactEditable onEditingOpen={ (e, value) => { console.log('editing started', value) }} content="hello this thing is editable" />
 ```
 
 ## onEditingClose
 Fires on when user open textarea to edit text wth textarea updated value
 ```html
-<SimpleReactComponent onEditingClose={ (e, value) => { console.log('editing closed', value) }} content="hello this thing is editable" />
+<SimpleReactEditable onEditingClose={ (e, value) => { console.log('editing closed', value) }} content="hello this thing is editable" />
+```
+
+## textfield
+Add the property `textfield` to get a texfield instead of a textarea when editing the text. This is usefull when you want to only edit a single line of text.
+```html
+<SimpleReactEditable textfield content="this is single-line editable" />
 ```
 
 Customize look and feel
 -----------------------
-You can customize the look and feel of the element using css classes provide by the `<SimpleReactComponent />`
+You can customize the look and feel of the element using css classes provide by the `<SimpleReactEditable />`
 
 ### .sre-edit-area
 The textarea visible upon ediing the text

--- a/src/simple-react-editable.jsx
+++ b/src/simple-react-editable.jsx
@@ -2,82 +2,86 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 export default class SimpleReactEditable extends React.Component {
-	constructor(props) {
-		super(props);
-		this.state = {
-			editing: false,
-			content: '',
-			element_class: 'sre'
-		};
-		this.openEditing = this.openEditing.bind(this);
-		this.closeEditing = this.closeEditing.bind(this);
-		this.changeContent = this.changeContent.bind(this);
-		this.renderEditable = this.renderEditable.bind(this);
-		this.renderPreview = this.renderPreview.bind(this);
-	}
+    constructor(props) {
+        super(props);
+        this.state = {
+            editing: false,
+            content: '',
+            element_class: 'sre'
+        };
+        this.openEditing = this.openEditing.bind(this);
+        this.closeEditing = this.closeEditing.bind(this);
+        this.changeContent = this.changeContent.bind(this);
+        this.renderEditable = this.renderEditable.bind(this);
+        this.renderPreview = this.renderPreview.bind(this);
+    }
 
-	componentDidMount() {
-		this.setState({
-			content: this.props.content ? this.props.content: ''
-		});
-	}
+    componentDidMount() {
+        this.setState({
+            content: this.props.content ? this.props.content: ''
+        });
+    }
 
-	closeEditing (e) {
-		let editing = this.state.editing;
-		this.setState({
-			editing: false
-		})
+    closeEditing (e) {
+        let editing = this.state.editing;
+        this.setState({
+            editing: false
+        })
 
-		// if props are passed call them
-		if(this.props.onEditingClose){
-			this.props.onEditingClose(e, this.state.content);
-		}
-	}
+        // if props are passed call them
+        if(this.props.onEditingClose){
+            this.props.onEditingClose(e, this.state.content);
+        }
+    }
 
-	openEditing (e) {
-		let editing = this.state.editing;
-		this.setState({
-			editing: true
-		})
+    openEditing (e) {
+        let editing = this.state.editing;
+        this.setState({
+            editing: true
+        })
 
-		// if props are passed call them
-		if(this.props.onEditingOpen){
-			this.props.onEditingOpen(e, this.state.content);
-		}
-	}
+        // if props are passed call them
+        if(this.props.onEditingOpen){
+            this.props.onEditingOpen(e, this.state.content);
+        }
+    }
 
 
-	changeContent (e) {
-		let content = e.target.value;
-		this.setState({
-			content: content
-		})
-	}
+    changeContent (e) {
+        let content = e.target.value;
+        this.setState({
+            content: content
+        })
+    }
 
-	renderEditable () {
-		return (
-			<div>
-				<textarea autoFocus className={this.state.element_class + "-edit-area"} onChange={this.changeContent} value={this.state.content} onBlur={this.closeEditing}/>
-				<div>
-					<button className={this.state.element_class + "-close-btn"} onClick={this.closeEditing} type="button">Close</button>
-				</div>
-			</div>
-		)
-	}
+    renderEditable () {
+        return (
+            <div>
+                {this.props.textfield ?
+                    <input autoFocus className={this.state.element_class + "-edit-area"} onChange={this.changeContent} value={this.state.content} onBlur={this.closeEditing}/>
+                        :
+                    <textarea autoFocus className={this.state.element_class + "-edit-area"} onChange={this.changeContent} value={this.state.content} onBlur={this.closeEditing}/>
+                }
+                <div>
+                    <button className={this.state.element_class + "-close-btn"} onClick={this.closeEditing} type="button">Close</button>
+                </div>
+            </div>
+        )
+    }
 
-	renderPreview () {
-		return (
-			<span className={this.state.element_class + "-preview"} onClick={this.openEditing}>
+    renderPreview () {
+        return (
+            <span className={this.state.element_class + "-preview"} onClick={this.openEditing}>
 				{this.state.content}
 			</span>
-		)
-	}
+        )
+    }
 
-	render() {
-		return(
-			<div>
-				{this.state.editing ? (this.renderEditable()) : (this.renderPreview())}
-			</div>
-		)
-	}
+    render() {
+        return(
+            <div>
+                {this.state.editing ? (this.renderEditable()) : (this.renderPreview())}
+            </div>
+        )
+    }
 }


### PR DESCRIPTION
Add the property `textfield` to get a texfield instead of a textarea when editing the text. This is usefull when you want to only edit a single line of text.

Tested and 100% backwards compatible.